### PR TITLE
Add conditional provider

### DIFF
--- a/src/FSharp.Data.LiteralProviders.DesignTime/Conditional.fs
+++ b/src/FSharp.Data.LiteralProviders.DesignTime/Conditional.fs
@@ -1,0 +1,80 @@
+﻿module internal FSharp.Data.LiteralProviders.DesignTime.ConditionalProvider
+
+open ProviderImplementation.ProvidedTypes
+
+let createCond<'T when 'T : equality and 'T : comparison> asm ns name func =
+    let ty = ProvidedTypeDefinition(asm, ns, name, None)
+    ty.DefineStaticParameters(
+        [ ProvidedStaticParameter("Left", typeof<'T>)
+          ProvidedStaticParameter("Right", typeof<'T>) ],
+        fun tyName args ->
+            match args with
+            | [| :? 'T as left; :? 'T as right |] ->
+                let ty = ProvidedTypeDefinition(asm, ns, tyName, None)
+                ProvidedField.Literal("Value", typeof<bool>, func left right)
+                |> ty.AddMember
+                ty
+            | _ -> failwithf "Invalid args: %A" args)
+    ty
+
+let createUnary<'T, 'U> asm ns name func =
+    let ty = ProvidedTypeDefinition(asm, ns, name, None)
+    ty.DefineStaticParameters(
+        [ ProvidedStaticParameter("Arg", typeof<'T>) ],
+        fun tyName args ->
+            match args with
+            | [| :? 'T as arg |] ->
+                let ty = ProvidedTypeDefinition(asm, ns, tyName, None)
+                ProvidedField.Literal("Value", typeof<'U>, func arg)
+                |> ty.AddMember
+                ty
+            | _ -> failwithf "Invalid args: %A" args)
+    ty
+
+let createIf<'T> asm ns =
+    let ty = ProvidedTypeDefinition(asm, ns, "IF", None)
+    ty.DefineStaticParameters(
+        [ ProvidedStaticParameter("Condition", typeof<bool>)
+          ProvidedStaticParameter("Then", typeof<'T>)
+          ProvidedStaticParameter("Else", typeof<'T>) ],
+        fun tyName args ->
+            match args with
+            | [| :? bool as cond; :? 'T as then'; :? 'T as else' |] ->
+                let ty = ProvidedTypeDefinition(asm, ns, tyName, None)
+                ProvidedField.Literal("Value", typeof<'T>, if cond then then' else else')
+                |> ty.AddMember
+                ty
+            | _ -> failwithf "Invalid args: %A" args)
+    ty
+
+let createEquality<'T when 'T : equality and 'T : comparison> asm ns =
+    [ createCond<'T> asm ns "EQ" (=)
+      createCond<'T> asm ns "NE" (<>) ]
+
+let createBoolOps asm ns =
+    [ createCond<bool> asm ns "AND" (&&)
+      createCond<bool> asm ns "OR" (||)
+      createCond<bool> asm ns "XOR" (<>)
+      createUnary<bool, bool> asm ns "NOT" not ]
+
+let createComparison<'T when 'T : equality and 'T : comparison> asm ns =
+    [ createCond<'T> asm ns "LT" (<)
+      createCond<'T> asm ns "LE" (<=)
+      createCond<'T> asm ns "GT" (>)
+      createCond<'T> asm ns "GE" (>=) ]
+
+let create asm ns =
+    let nsString = ns + ".String"
+    let nsBool = ns + ".Bool"
+    let nsInt = ns + ".Int"
+
+    [ yield createIf<string> asm nsString
+      yield! createEquality<string> asm nsString
+
+      yield createIf<bool> asm nsBool
+      yield! createEquality<bool> asm nsBool
+      yield! createBoolOps asm nsBool
+
+      yield createIf<int> asm nsInt
+      yield! createEquality<int> asm nsInt
+      yield! createComparison<int> asm nsInt ]

--- a/src/FSharp.Data.LiteralProviders.DesignTime/FSharp.Data.LiteralProviders.DesignTime.fsproj
+++ b/src/FSharp.Data.LiteralProviders.DesignTime/FSharp.Data.LiteralProviders.DesignTime.fsproj
@@ -25,6 +25,7 @@
     <Compile Include="TextFile.fs" />
     <Compile Include="BuildDate.fs" />
     <Compile Include="Exec.fs" />
+    <Compile Include="Conditional.fs" />
     <Compile Include="Provider.fs" />
     <None Include="paket.references" />
   </ItemGroup>

--- a/src/FSharp.Data.LiteralProviders.DesignTime/Provider.fs
+++ b/src/FSharp.Data.LiteralProviders.DesignTime/Provider.fs
@@ -11,13 +11,14 @@ type Provider(config) as this =
     let ns = "FSharp.Data.LiteralProviders"
     let asm = Assembly.GetExecutingAssembly()
 
-    let createTypes() =
-        [ EnvProvider.create asm ns config.ResolutionFolder
-          TextFileProvider.create asm ns config.ResolutionFolder
-          BuildDateProvider.create asm ns
-          ExecProvider.create asm ns config.ResolutionFolder ]
-
-    do this.AddNamespace(ns, createTypes())
+    do
+        [ yield EnvProvider.create asm ns config.ResolutionFolder
+          yield TextFileProvider.create asm ns config.ResolutionFolder
+          yield BuildDateProvider.create asm ns
+          yield ExecProvider.create asm ns config.ResolutionFolder
+          yield! ConditionalProvider.create asm ns ]
+        |> List.groupBy (fun t -> t.Namespace)
+        |> List.iter this.AddNamespace
 
 [<assembly:TypeProviderAssembly>]
 do ()

--- a/tests/FSharp.Data.LiteralProviders.Tests/Conditional.fs
+++ b/tests/FSharp.Data.LiteralProviders.Tests/Conditional.fs
@@ -1,0 +1,99 @@
+﻿module FSharp.Data.LiteralProviders.Tests.Conditional
+
+open NUnit.Framework
+open FSharp.Data.LiteralProviders
+
+module String =
+
+    [<Test>]
+    let ``if`` () =
+        Assert.AreEqual("First", String.IF<true, Then = "First", Else = "Second">.Value)
+        Assert.AreEqual("Second", String.IF<false, Then = "First", Else = "Second">.Value)
+
+    [<Test>]
+    let equal () =
+        Assert.IsTrue(String.EQ<"A", "A">.Value)
+        Assert.IsFalse(String.EQ<"A", "B">.Value)
+
+    [<Test>]
+    let ``not equal`` () =
+        Assert.IsFalse(String.NE<"A", "A">.Value)
+        Assert.IsTrue(String.NE<"A", "B">.Value)
+
+module Bool =
+
+    [<Test>]
+    let ``if`` () =
+        Assert.IsTrue(Bool.IF<true, Then = true, Else = false>.Value)
+        Assert.IsFalse(Bool.IF<false, Then = true, Else = false>.Value)
+
+    [<Test>]
+    let equal () =
+        Assert.IsTrue(Bool.EQ<true, true>.Value)
+        Assert.IsFalse(Bool.EQ<true, false>.Value)
+
+    [<Test>]
+    let ``not equal`` () =
+        Assert.IsFalse(Bool.NE<true, true>.Value)
+        Assert.IsTrue(Bool.NE<true, false>.Value)
+        
+    [<Test>]
+    let ``and`` () =
+        Assert.IsTrue(Bool.AND<true, true>.Value)
+        Assert.IsFalse(Bool.AND<true, false>.Value)
+
+    [<Test>]
+    let ``or`` () =
+        Assert.IsTrue(Bool.OR<true, false>.Value)
+        Assert.IsFalse(Bool.OR<false, false>.Value)
+
+    [<Test>]
+    let xor () =
+        Assert.IsFalse(Bool.XOR<true, true>.Value)
+        Assert.IsTrue(Bool.XOR<true, false>.Value)
+        
+    [<Test>]
+    let not () =
+        Assert.IsFalse(Bool.NOT<true>.Value)
+        Assert.IsTrue(Bool.NOT<false>.Value)
+
+module Int =
+
+    [<Test>]
+    let ``if`` () =
+        Assert.AreEqual(4, Int.IF<true, Then = 4, Else = 5>.Value)
+        Assert.AreEqual(5, Int.IF<false, Then = 4, Else = 5>.Value)
+
+    [<Test>]
+    let equal () =
+        Assert.IsTrue(Int.EQ<4, 4>.Value)
+        Assert.IsFalse(Int.EQ<4, 5>.Value)
+
+    [<Test>]
+    let ``not equal`` () =
+        Assert.IsFalse(Int.NE<4, 4>.Value)
+        Assert.IsTrue(Int.NE<4, 5>.Value)
+
+    [<Test>]
+    let ``less than`` () =
+        Assert.IsTrue(Int.LT<4, 5>.Value)
+        Assert.IsFalse(Int.LT<4, 4>.Value)
+        Assert.IsFalse(Int.LT<5, 4>.Value)
+
+    [<Test>]
+    let ``less than or equal`` () =
+        Assert.IsTrue(Int.LE<4, 5>.Value)
+        Assert.IsTrue(Int.LE<4, 4>.Value)
+        Assert.IsFalse(Int.LE<5, 4>.Value)
+
+    [<Test>]
+    let ``greater than`` () =
+        Assert.IsFalse(Int.GT<4, 5>.Value)
+        Assert.IsFalse(Int.GT<4, 4>.Value)
+        Assert.IsTrue(Int.GT<5, 4>.Value)
+
+    [<Test>]
+    let ``greater than or equal`` () =
+        Assert.IsFalse(Int.GE<4, 5>.Value)
+        Assert.IsTrue(Int.GE<4, 4>.Value)
+        Assert.IsTrue(Int.GE<5, 4>.Value)

--- a/tests/FSharp.Data.LiteralProviders.Tests/FSharp.Data.LiteralProviders.Tests.fsproj
+++ b/tests/FSharp.Data.LiteralProviders.Tests/FSharp.Data.LiteralProviders.Tests.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="TextFile.fs" />
     <Compile Include="BuildDate.fs" />
     <Compile Include="Exec.fs" />
+    <Compile Include="Conditional.fs" />
     <Content Include=".env" />
     <Content Include="subdir\*.*" />
     <None Include="paket.references" />


### PR DESCRIPTION
Add providers for conditions on static values. They are in the `String`, `Int` and `Bool` subnamespace depending on the type they act on.

* `IF<cond, Then = x, Else = y>.Value` for if/then/else
* `EQ<x, y>.Value`, `NE<x, y>.Value` for (in)equality
* `LT<x, y>.Value`, `LE<x, y>.Value`, `GT<x, y>.Value`, `GE<x, y>.Value` for comparison (`Int` only)
* `AND<x, y>.Value`, `OR<x, y>.Value`, `XOR<x, y>.Value`, `NOT<x>.Value` for boolean operations (`Bool` only)