### PR TITLE
Fix Exec provider not capturing stdout on .NET 8+

### DIFF
--- a/src/FSharp.Data.LiteralProviders.DesignTime/Exec.fs
+++ b/src/FSharp.Data.LiteralProviders.DesignTime/Exec.fs
@@ -77,6 +77,7 @@ let execute args =
     proc.Start() |> ignore
     let startTime = try proc.StartTime with _ -> DateTime.Now
     args.Input |> Option.iter proc.StandardInput.Write
+    proc.StandardInput.Close()
     proc.BeginOutputReadLine()
     proc.BeginErrorReadLine()
     if not (proc.WaitForExit(args.Timeout)) then

--- a/tests/FSharp.Data.LiteralProviders.Tests/Exec.fs
+++ b/tests/FSharp.Data.LiteralProviders.Tests/Exec.fs
@@ -60,3 +60,10 @@ type DotnetSlnError = Exec<"dotnet", "sln list", Directory = ".">
 let ``with directory failure`` () =
     test <@ DotnetSlnError.ExitCode = 1 @>
     test <@ DotnetSlnError.ErrorMessage = "Process exited with status code 1" @>
+
+type EchoHello = Exec<"echo", "hello">
+
+[<Test>]
+let ``stdout is captured`` () =
+    test <@ EchoHello.Output = "hello" @>
+    test <@ EchoHello.ExitCode = 0 @>


### PR DESCRIPTION
Close StandardInput after writing to signal EOF to the child process. Without this, processes may hang waiting for input, and the async output handlers (BeginOutputReadLine/BeginErrorReadLine) don't receive data properly on newer .NET versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)